### PR TITLE
Feature/issue 1 member entity

### DIFF
--- a/src/main/java/com/ikhyeon/plan_make/common/entity/BaseEntity.java
+++ b/src/main/java/com/ikhyeon/plan_make/common/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.ikhyeon.plan_make.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/ikhyeon/plan_make/domain/member/entity/Member.java
+++ b/src/main/java/com/ikhyeon/plan_make/domain/member/entity/Member.java
@@ -47,16 +47,6 @@ public class Member extends BaseEntity {
     private LocalDate lastPlanCreationDate;
 
     // 비즈니스 로직
-    public boolean canCreatePlanToday() {
-        LocalDate today = LocalDate.now();
-
-        // 마지막 계획 생성일이 오늘이 아니면 카운트 리셋
-        if (!today.equals(this.lastPlanCreationDate)) {
-            resetDailyPlanCount();
-        }
-
-        return this.dailyPlanCreationCount < 3;
-    }
 
     public void incrementPlanCreationCount() {
         LocalDate today = LocalDate.now();
@@ -71,6 +61,17 @@ public class Member extends BaseEntity {
 
         this.dailyPlanCreationCount++;
         this.lastPlanCreationDate = today;
+    }
+
+    public boolean canCreatePlanToday() {
+        LocalDate today = LocalDate.now();
+
+        // 마지막 계획 생성일이 오늘이 아니면 카운트 리셋
+        if (!today.equals(this.lastPlanCreationDate)) {
+            resetDailyPlanCount();
+        }
+
+        return this.dailyPlanCreationCount < 3;
     }
 
     private void resetDailyPlanCount() {

--- a/src/main/java/com/ikhyeon/plan_make/domain/member/entity/Member.java
+++ b/src/main/java/com/ikhyeon/plan_make/domain/member/entity/Member.java
@@ -51,27 +51,18 @@ public class Member extends BaseEntity {
     public void incrementPlanCreationCount() {
         LocalDate today = LocalDate.now();
 
-        if (!today.equals(this.lastPlanCreationDate)) {
-            resetDailyPlanCount();
+        // 현재 상태에서 신규 계획 생성 가능한지 확인
+        if (today.equals(this.lastPlanCreationDate) && this.dailyPlanCreationCount >= 3) {
+            throw new IllegalStateException("일일 계획 생성 한도를 초과했습니다.");
         }
 
-        if (!canCreatePlanToday()) {
-            throw new IllegalStateException("일일 계획 생성 한도를 초과했습니다.");
+        // 마지막 계획 생성 날짜가 과거라면 카운트 초기화
+        if (!today.equals(this.lastPlanCreationDate)) {
+            resetDailyPlanCount();
         }
 
         this.dailyPlanCreationCount++;
         this.lastPlanCreationDate = today;
-    }
-
-    public boolean canCreatePlanToday() {
-        LocalDate today = LocalDate.now();
-
-        // 마지막 계획 생성일이 오늘이 아니면 카운트 리셋
-        if (!today.equals(this.lastPlanCreationDate)) {
-            resetDailyPlanCount();
-        }
-
-        return this.dailyPlanCreationCount < 3;
     }
 
     private void resetDailyPlanCount() {

--- a/src/main/java/com/ikhyeon/plan_make/domain/member/entity/Member.java
+++ b/src/main/java/com/ikhyeon/plan_make/domain/member/entity/Member.java
@@ -1,0 +1,80 @@
+package com.ikhyeon.plan_make.domain.member.entity;
+
+import com.ikhyeon.plan_make.common.entity.BaseEntity;
+import com.ikhyeon.plan_make.domain.member.vo.SocialProvider;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SocialProvider socialProvider;
+
+    @Column(nullable = false)
+    private String socialId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String profileImageUrl;
+
+    @Column(nullable = false)
+    private Integer dailyPlanCreationCount = 0;
+
+    @Column(nullable = false)
+    private LocalDate lastPlanCreationDate;
+
+    // 비즈니스 로직
+    public boolean canCreatePlanToday() {
+        LocalDate today = LocalDate.now();
+
+        // 마지막 계획 생성일이 오늘이 아니면 카운트 리셋
+        if (!today.equals(this.lastPlanCreationDate)) {
+            resetDailyPlanCount();
+        }
+
+        return this.dailyPlanCreationCount < 3;
+    }
+
+    public void incrementPlanCreationCount() {
+        LocalDate today = LocalDate.now();
+
+        if (!today.equals(this.lastPlanCreationDate)) {
+            resetDailyPlanCount();
+        }
+
+        if (!canCreatePlanToday()) {
+            throw new IllegalStateException("일일 계획 생성 한도를 초과했습니다.");
+        }
+
+        this.dailyPlanCreationCount++;
+        this.lastPlanCreationDate = today;
+    }
+
+    private void resetDailyPlanCount() {
+        this.dailyPlanCreationCount = 0;
+        this.lastPlanCreationDate = LocalDate.now();
+    }
+}

--- a/src/main/java/com/ikhyeon/plan_make/domain/member/vo/SocialProvider.java
+++ b/src/main/java/com/ikhyeon/plan_make/domain/member/vo/SocialProvider.java
@@ -1,0 +1,17 @@
+package com.ikhyeon.plan_make.domain.member.vo;
+
+import lombok.Getter;
+
+@Getter
+public enum SocialProvider {
+    GOOGLE("google"),
+    KAKAO("kakao"),
+    NAVER("naver"),
+    GITHUB("github");
+
+    private final String value;
+
+    SocialProvider(String value) {
+        this.value = value;
+    }
+}

--- a/src/test/java/com/ikhyeon/plan_make/domain/member/entity/MemberTest.java
+++ b/src/test/java/com/ikhyeon/plan_make/domain/member/entity/MemberTest.java
@@ -1,0 +1,197 @@
+package com.ikhyeon.plan_make.domain.member.entity;
+
+import com.ikhyeon.plan_make.domain.member.vo.SocialProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Member 엔티티 테스트")
+class MemberTest {
+
+    @DisplayName("Member 생성 테스트")
+    @Nested
+    class CreateMemberTest {
+
+        @Test
+        @DisplayName("정상적으로 Member를 생성할 수 있다")
+        void createMember_Success() {
+            // given
+            SocialProvider socialProvider = SocialProvider.GOOGLE;
+            String socialId = "123456789";
+            String email = "test@example.com";
+            String name = "테스트유저";
+            String profileImageUrl = "https://example.com/profile.jpg";
+
+            // when
+            Member member = new Member(null, socialProvider, socialId, email, name, profileImageUrl, 0, LocalDate.now().minusDays(1));
+
+            // then
+            assertThat(member.getSocialProvider()).isEqualTo(socialProvider);
+            assertThat(member.getSocialId()).isEqualTo(socialId);
+            assertThat(member.getEmail()).isEqualTo(email);
+            assertThat(member.getName()).isEqualTo(name);
+            assertThat(member.getProfileImageUrl()).isEqualTo(profileImageUrl);
+            assertThat(member.getDailyPlanCreationCount()).isEqualTo(0);
+        }
+    }
+
+    @DisplayName("일일 계획 생성 테스트")
+    @Nested
+    class DailyPlanCreationTest {
+
+        private Member createTestMember() {
+            return new Member(null, SocialProvider.GOOGLE, "123456789", "test@example.com", 
+                            "테스트유저", "https://example.com/profile.jpg", 0, LocalDate.now().minusDays(1));
+        }
+
+        @Test
+        @DisplayName("첫 번째 계획 생성 시 정상적으로 카운트가 증가한다")
+        void incrementPlanCreationCount_FirstTime_Success() {
+            // given
+            Member member = createTestMember();
+
+            // when
+            member.incrementPlanCreationCount();
+
+            // then
+            assertThat(member.getDailyPlanCreationCount()).isEqualTo(1);
+            assertThat(member.getLastPlanCreationDate()).isEqualTo(LocalDate.now());
+        }
+
+        @Test
+        @DisplayName("같은 날 3번째까지 계획 생성이 가능하다")
+        void incrementPlanCreationCount_ThreeTimes_Success() {
+            // given
+            Member member = createTestMember();
+
+            // when & then
+            member.incrementPlanCreationCount();
+            assertThat(member.getDailyPlanCreationCount()).isEqualTo(1);
+
+            member.incrementPlanCreationCount();
+            assertThat(member.getDailyPlanCreationCount()).isEqualTo(2);
+
+            member.incrementPlanCreationCount();
+            assertThat(member.getDailyPlanCreationCount()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("같은 날 4번째 계획 생성 시 예외가 발생한다")
+        void incrementPlanCreationCount_FourthTime_ThrowsException() {
+            // given
+            Member member = createTestMember();
+            member.incrementPlanCreationCount();
+            member.incrementPlanCreationCount();
+            member.incrementPlanCreationCount();
+
+            // when & then
+            assertThatThrownBy(member::incrementPlanCreationCount)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("일일 계획 생성 한도를 초과했습니다.");
+        }
+
+        @Test
+        @DisplayName("새로운 날에는 카운트가 리셋되어 다시 생성할 수 있다")
+        void incrementPlanCreationCount_NewDay_ResetsCount() {
+            // given
+            Member member = new Member(null, SocialProvider.GOOGLE, "123456789", "test@example.com", 
+                                     "테스트유저", "https://example.com/profile.jpg", 3, LocalDate.now().minusDays(1));
+
+            // when
+            member.incrementPlanCreationCount();
+
+            // then
+            assertThat(member.getDailyPlanCreationCount()).isEqualTo(1);
+            assertThat(member.getLastPlanCreationDate()).isEqualTo(LocalDate.now());
+        }
+    }
+
+    @DisplayName("계획 생성 가능 여부 테스트")
+    @Nested
+    class CanCreatePlanTodayTest {
+
+        @Test
+        @DisplayName("계획을 생성한 적이 없으면 생성 가능하다")
+        void canCreatePlanToday_NeverCreated_ReturnsTrue() {
+            // given
+            Member member = new Member(null, SocialProvider.GOOGLE, "123456789", "test@example.com", 
+                                     "테스트유저", "https://example.com/profile.jpg", 0, LocalDate.now().minusDays(1));
+
+            // when & then
+            assertThat(member.canCreatePlanToday()).isTrue();
+        }
+
+        @Test
+        @DisplayName("오늘 2번 생성했으면 아직 생성 가능하다")
+        void canCreatePlanToday_TwoTimesToday_ReturnsTrue() {
+            // given
+            Member member = new Member(null, SocialProvider.GOOGLE, "123456789", "test@example.com", 
+                                     "테스트유저", "https://example.com/profile.jpg", 2, LocalDate.now());
+
+            // when & then
+            assertThat(member.canCreatePlanToday()).isTrue();
+        }
+
+        @Test
+        @DisplayName("오늘 3번 생성했으면 더 이상 생성할 수 없다")
+        void canCreatePlanToday_ThreeTimesToday_ReturnsFalse() {
+            // given
+            Member member = new Member(null, SocialProvider.GOOGLE, "123456789", "test@example.com", 
+                                     "테스트유저", "https://example.com/profile.jpg", 3, LocalDate.now());
+
+            // when & then
+            assertThat(member.canCreatePlanToday()).isFalse();
+        }
+
+        @Test
+        @DisplayName("어제 3번 생성했어도 오늘은 생성 가능하다")
+        void canCreatePlanToday_ThreeTimesYesterday_ReturnsTrue() {
+            // given
+            Member member = new Member(null, SocialProvider.GOOGLE, "123456789", "test@example.com", 
+                                     "테스트유저", "https://example.com/profile.jpg", 3, LocalDate.now().minusDays(1));
+
+            // when & then
+            assertThat(member.canCreatePlanToday()).isTrue();
+        }
+    }
+
+    @DisplayName("일일 카운트 리셋 테스트")
+    @Nested
+    class ResetDailyPlanCountTest {
+
+        @Test
+        @DisplayName("canCreatePlanToday 호출 시 날짜가 다르면 카운트가 리셋된다")
+        void canCreatePlanToday_DifferentDate_ResetsCount() {
+            // given
+            Member member = new Member(null, SocialProvider.GOOGLE, "123456789", "test@example.com", 
+                                     "테스트유저", "https://example.com/profile.jpg", 3, LocalDate.now().minusDays(1));
+
+            // when
+            boolean canCreate = member.canCreatePlanToday();
+
+            // then
+            assertThat(canCreate).isTrue();
+            assertThat(member.getDailyPlanCreationCount()).isEqualTo(0);
+            assertThat(member.getLastPlanCreationDate()).isEqualTo(LocalDate.now());
+        }
+
+        @Test
+        @DisplayName("incrementPlanCreationCount 호출 시 날짜가 다르면 카운트가 리셋된다")
+        void incrementPlanCreationCount_DifferentDate_ResetsCount() {
+            // given
+            Member member = new Member(null, SocialProvider.GOOGLE, "123456789", "test@example.com", 
+                                     "테스트유저", "https://example.com/profile.jpg", 3, LocalDate.now().minusDays(1));
+
+            // when
+            member.incrementPlanCreationCount();
+
+            // then
+            assertThat(member.getDailyPlanCreationCount()).isEqualTo(1);
+            assertThat(member.getLastPlanCreationDate()).isEqualTo(LocalDate.now());
+        }
+    }
+}


### PR DESCRIPTION
- `BaseEntity` 개발 완료
- `Member` 개발 완료
- 유저당 하루 최대 3개 계획 생성 가능하도록 비지니스 로직 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원 정보를 관리하는 엔티티가 추가되어, 소셜 로그인 제공자, 이메일, 이름, 프로필 이미지, 일일 플랜 생성 횟수 및 마지막 플랜 생성일을 포함합니다.
  * 일일 플랜 생성 제한(하루 최대 3개) 기능이 적용되어, 초과 시 예외가 발생합니다.
  * 소셜 로그인 제공자(GOOGLE, KAKAO, NAVER, GITHUB) 선택이 가능합니다.
  * 생성 및 수정 일시를 자동으로 기록하는 기능이 도입되었습니다.

* **테스트**
  * 회원 엔티티의 생성, 일일 플랜 생성 제한, 날짜 변경 시 카운트 초기화, 예외 처리 등에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->